### PR TITLE
Finalize public formats API and add test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # JSONSchema Changelog
+
+## 0.4.0
+
+- Converted project to Swift 3
+
 ## 0.3.0
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.4.0
 
 - Converted project to Swift 3
+- Adds `addFormat` method to `Schema` which supports custom format definitions
+- Renames `ValidationResult.Valid` to `ValidationResult.valid` to match Swift 3 naming conventions
 
 ## 0.3.0
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ schema.addFormat(formatKey: "alpha") { (value) -> (ValidationResult) in
         if leftover.characters.count > 0 {
             return .invalid(["\(str) contains non-alpha characters"])
         }
-        return .Valid
+        return .valid
     }
 
-    return .Valid
+    return .valid
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ let schema = Schema([
 schema.validate(["name": "Eggs", "price": 34.99])
 ```
 
+### Adding custom formats
+
+```swift
+// Note: custom formats will automatically be combined with a string type validator
+schema.addFormat(formatKey: "alpha") { (value) -> (ValidationResult) in
+    if let str = value as? String {
+        let allowedCharacters = CharacterSet.letters
+        let c = str.components(separatedBy: allowedCharacters)
+        let leftover = (c as NSArray).componentsJoined(by: "")
+        if leftover.characters.count > 0 {
+            return .invalid(["\(str) contains non-alpha characters"])
+        }
+        return .Valid
+    }
+
+    return .Valid
+}
+```
+
 ### Error handling
 
 Validate returns an enumeration `ValidationResult` which contains all

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 An implementation of [JSON Schema](http://json-schema.org/) in Swift.
 
+## Requirements
+
+The latest version of `JSON Schema` requires Swift `3`.
+
+If you are using Swift `2.2` then use version `0.3.0` of `JSON Schema`.
+
 ## Installation
 
 [CocoaPods](http://cocoapods.org/) is the recommended installation method.

--- a/Sources/JSONSchema.swift
+++ b/Sources/JSONSchema.swift
@@ -56,10 +56,9 @@ public struct Schema {
 
     self.schema = schema
 
-    formats = [
-      "ipv4": validateIPv4,
-      "ipv6": validateIPv6,
-    ]
+    formats = [:]
+    addFormat(formatKey: "ipv4", format: validateIPv4)
+    addFormat(formatKey: "ipv6", format: validateIPv6)
   }
 
   public func validate(_ data:Any) -> ValidationResult {
@@ -68,8 +67,9 @@ public struct Schema {
     return result
   }
 
-  public mutating func addFormat(formatKey: String, format: Validator) {
-    formats[formatKey] = format
+  public mutating func addFormat(formatKey: String, format: @escaping Validator) {
+    let validator = allOf([validateType(Type.String.rawValue), format])
+    formats[formatKey] = validator
   }
 
   func validatorForReference(_ reference:String) -> Validator {

--- a/Sources/JSONSchema.swift
+++ b/Sources/JSONSchema.swift
@@ -35,9 +35,7 @@ public struct Schema {
 
   public let type:[Type]?
 
-  /// validation formats, currently private. If anyone wants to add custom please make a PR to make this public ;)
-  let formats:[String:Validator]
-
+  var formats:[String:Validator]
   let schema:[String:Any]
 
   public init(_ schema:[String:Any]) {
@@ -68,6 +66,10 @@ public struct Schema {
     let validator = allOf(validators(self)(schema))
     let result = validator(data)
     return result
+  }
+
+  public mutating func addFormat(formatKey: String, format: Validator) {
+    formats[formatKey] = format
   }
 
   func validatorForReference(_ reference:String) -> Validator {

--- a/Sources/JSONSchema.swift
+++ b/Sources/JSONSchema.swift
@@ -201,7 +201,7 @@ func validators(_ root: Schema) -> (_ schema: [String:Any]) -> [Validator] {
           return flatten(document.map(itemsValidators))
         }
 
-        return .Valid
+        return .valid
       }
 
       validators.append(validateItems)
@@ -238,7 +238,7 @@ func validators(_ root: Schema) -> (_ schema: [String:Any]) -> [Validator] {
           return flatten(results)
         }
 
-        return .Valid
+        return .valid
       }
 
       validators.append(validateItems)
@@ -294,7 +294,7 @@ func validators(_ root: Schema) -> (_ schema: [String:Any]) -> [Validator] {
           }
         }
 
-        return .Valid
+        return .valid
       }
     }
 
@@ -306,12 +306,12 @@ func validators(_ root: Schema) -> (_ schema: [String:Any]) -> [Validator] {
               if value[dependency] == nil {
                 return .invalid(["'\(key)' is missing it's dependency of '\(dependency)'"])
               }
-              return .Valid
+              return .valid
             })
           }
         }
 
-        return .Valid
+        return .valid
       }
     }
 

--- a/Sources/Validators.swift
+++ b/Sources/Validators.swift
@@ -10,12 +10,12 @@ import Foundation
 
 
 public enum ValidationResult {
-  case Valid
+  case valid
   case invalid([String])
 
   public var valid: Bool {
     switch self {
-    case .Valid:
+    case .valid:
       return true
     case .invalid:
       return false
@@ -24,7 +24,7 @@ public enum ValidationResult {
 
   public var errors:[String]? {
     switch self {
-    case .Valid:
+    case .valid:
       return nil
     case .invalid(let errors):
       return errors
@@ -50,12 +50,12 @@ func flatten(_ results:[ValidationResult]) -> ValidationResult {
     return .invalid(errors)
   }
 
-  return .Valid
+  return .valid
 }
 
 /// Creates a Validator which always returns an valid result
 func validValidation(_ value:Any) -> ValidationResult {
-  return .Valid
+  return .valid
 }
 
 /// Creates a Validator which always returns an invalid result with the given error
@@ -74,36 +74,36 @@ func validateType(_ type: String) -> (_ value: Any) -> ValidationResult {
     case "integer":
       if let number = value as? NSNumber {
         if !CFNumberIsFloatType(number) && CFGetTypeID(number) != CFBooleanGetTypeID() {
-          return .Valid
+          return .valid
         }
       }
     case "number":
       if let number = value as? NSNumber {
         if CFGetTypeID(number) != CFBooleanGetTypeID() {
-          return .Valid
+          return .valid
         }
       }
     case "string":
       if value is String {
-        return .Valid
+        return .valid
       }
     case "object":
       if value is NSDictionary {
-        return .Valid
+        return .valid
       }
     case "array":
       if value is NSArray {
-        return .Valid
+        return .valid
       }
     case "boolean":
       if let number = value as? NSNumber {
         if CFGetTypeID(number) == CFBooleanGetTypeID() {
-          return .Valid
+          return .valid
         }
       }
     case "null":
       if value is NSNull {
-        return .Valid
+        return .valid
       }
     default:
       break
@@ -136,7 +136,7 @@ func anyOf(_ validators:[Validator], error:String? = nil) -> (_ value: Any) -> V
     for validator in validators {
       let result = validator(value)
       if result.valid {
-        return .Valid
+        return .valid
       }
     }
 
@@ -154,7 +154,7 @@ func oneOf(_ validators: [Validator]) -> (_ value: Any) -> ValidationResult {
     let validValidators = results.filter { $0.valid }.count
 
     if validValidators == 1 {
-      return .Valid
+      return .valid
     }
 
     return .invalid(["\(validValidators) validates instead `oneOf`."])
@@ -168,7 +168,7 @@ func not(_ validator: @escaping Validator) -> (_ value: Any) -> ValidationResult
       return .invalid(["'\(value)' does not match 'not' validation."])
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -181,7 +181,7 @@ func allOf(_ validators: [Validator]) -> (_ value: Any) -> ValidationResult {
 func validateEnum(_ values: [Any]) -> (_ value: Any) -> ValidationResult {
   return { value in
     if (values as! [NSObject]).contains(value as! NSObject) {
-      return .Valid
+      return .valid
     }
 
     return .invalid(["'\(value)' is not a valid enumeration value of '\(values)'"])
@@ -198,7 +198,7 @@ func validateLength(_ comparitor: @escaping ((Int, Int) -> (Bool)), length: Int,
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -216,7 +216,7 @@ func validatePattern(_ pattern: String) -> (_ value: Any) -> ValidationResult {
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -233,7 +233,7 @@ func validateMultipleOf(_ number: Double) -> (_ value: Any) -> ValidationResult 
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -251,7 +251,7 @@ func validateNumericLength(_ length: Double, comparitor: @escaping ((Double, Dou
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -265,7 +265,7 @@ func validateArrayLength(_ rhs: Int, comparitor: @escaping ((Int, Int) -> Bool),
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -286,13 +286,13 @@ func validateUniqueItems(_ value: Any) -> ValidationResult {
     let delta = (hasTrueAndOne ? 1 : 0) + (hasFalseAndZero ? 1 : 0)
 
     if (NSSet(array: value).count + delta) == value.count {
-      return .Valid
+      return .valid
     }
 
     return .invalid(["\(value) does not have unique items"])
   }
 
-  return .Valid
+  return .valid
 }
 
 // MARK: Object
@@ -305,7 +305,7 @@ func validatePropertiesLength(_ length: Int, comparitor: @escaping ((Int, Int) -
       }
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -313,13 +313,13 @@ func validateRequired(_ required: [String]) -> (_ value: Any)  -> ValidationResu
   return { value in
     if let value = value as? [String:Any] {
       if (required.filter { r in !value.keys.contains(r) }.count == 0) {
-        return .Valid
+        return .valid
       }
 
       return .invalid(["Required properties are missing '\(required)'"])
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -363,7 +363,7 @@ func validateProperties(_ properties: [String:Validator]?, patternProperties: [S
       return flatten(results)
     }
 
-    return .Valid
+    return .valid
   }
 }
 
@@ -401,24 +401,24 @@ func validateIPv4(_ value:Any) -> ValidationResult {
   if let ipv4 = value as? String {
     var sin = sockaddr_in()
     if ipv4.trimmingCharacters(in: .whitespaces).withCString({ cstring in inet_pton(AF_INET, cstring, &sin.sin_addr) }) == 1 {
-      return .Valid
+      return .valid
     }
 
     return .invalid(["'\(ipv4)' is not valid IPv4 address."])
   }
 
-  return .Valid
+  return .valid
 }
 
 func validateIPv6(_ value:Any) -> ValidationResult {
   if let ipv6 = value as? String {
     var sin = sockaddr_in6()
     if ipv6.trimmingCharacters(in: .whitespaces).withCString({ cstring in inet_pton(AF_INET6, cstring, &sin.sin6_addr) }) == 1 {
-      return .Valid
+      return .valid
     }
 
     return .invalid(["'\(ipv6)' is not valid IPv6 address."])
   }
 
-  return .Valid
+  return .valid
 }

--- a/Sources/Validators.swift
+++ b/Sources/Validators.swift
@@ -33,7 +33,7 @@ public enum ValidationResult {
 }
 
 typealias LegacyValidator = (Any) -> (Bool)
-typealias Validator = (Any) -> (ValidationResult)
+public typealias Validator = (Any) -> (ValidationResult)
 
 /// Flatten an array of results into a single result (combining all errors)
 func flatten(_ results:[ValidationResult]) -> ValidationResult {

--- a/Sources/Validators.swift
+++ b/Sources/Validators.swift
@@ -399,10 +399,9 @@ func validateDependencies(_ key: String, dependencies: [String]) -> (_ value: An
 
 func validateIPv4(_ value:Any) -> ValidationResult {
   if let ipv4 = value as? String {
-    if let expression = try? NSRegularExpression(pattern: "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", options: NSRegularExpression.Options(rawValue: 0)) {
-      if expression.matches(in: ipv4, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, ipv4.characters.count)).count == 1 {
-        return .Valid
-      }
+    var sin = sockaddr_in()
+    if ipv4.trimmingCharacters(in: .whitespaces).withCString({ cstring in inet_pton(AF_INET, cstring, &sin.sin_addr) }) == 1 {
+      return .Valid
     }
 
     return .invalid(["'\(ipv4)' is not valid IPv4 address."])
@@ -413,8 +412,8 @@ func validateIPv4(_ value:Any) -> ValidationResult {
 
 func validateIPv6(_ value:Any) -> ValidationResult {
   if let ipv6 = value as? String {
-    var buf = UnsafeMutablePointer<Int8>.allocate(capacity: Int(INET6_ADDRSTRLEN))
-    if inet_pton(AF_INET6, ipv6, &buf) == 1 {
+    var sin = sockaddr_in6()
+    if ipv6.trimmingCharacters(in: .whitespaces).withCString({ cstring in inet_pton(AF_INET6, cstring, &sin.sin6_addr) }) == 1 {
       return .Valid
     }
 

--- a/Tests/JSONSchemaCases.swift
+++ b/Tests/JSONSchemaCases.swift
@@ -107,7 +107,7 @@ func makeAssertions(_ c:Case) -> ([Assertion]) {
     return ("\(c.description) \(test.description)", {
       let result = validate(test.data, schema: c.schema)
       switch result {
-      case .Valid:
+      case .valid:
         XCTAssertEqual(result.valid, test.value, "Result is valid")
       case .invalid(let errors):
         XCTAssertEqual(result.valid, test.value, "Failed validation: \(errors)")

--- a/Tests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaTests.swift
@@ -73,10 +73,10 @@ class JSONSchemaTests: XCTestCase {
         if leftover.characters.count > 0 {
           return .invalid(["\(str) contains non-alpha characters"])
         }
-        return .Valid
+        return .valid
       }
 
-      return .Valid
+      return .valid
     }
 
     XCTAssertTrue(schema.validate(["letters": "HelloWorld"]).valid)

--- a/Tests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaTests.swift
@@ -56,4 +56,647 @@ class JSONSchemaTests: XCTestCase {
     XCTAssertTrue(schema.validate(["name": "Eggs", "price": 34.99]).valid)
     XCTAssertFalse(schema.validate(["price": 34.99]).valid)
   }
+
+  func testAddFormat() {
+    var schema = Schema([
+      "type": "object",
+      "properties": [
+        "letters": ["type": "string", "format": "alpha"],
+      ],
+      "required": ["letters"],
+      ])
+    schema.addFormat(formatKey: "alpha") { (value) -> (ValidationResult) in
+      if let str = value as? String {
+        let allowedCharacters = CharacterSet.letters
+        let c = str.components(separatedBy: allowedCharacters)
+        let leftover = (c as NSArray).componentsJoined(by: "")
+        if leftover.characters.count > 0 {
+          return .invalid(["\(str) contains non-alpha characters"])
+        }
+        return .Valid
+      }
+
+      return .Valid
+    }
+
+    XCTAssertTrue(schema.validate(["letters": "HelloWorld"]).valid)
+    XCTAssertFalse(schema.validate(["letters": "Hello World"]).valid)
+    XCTAssertFalse(schema.validate(["letters": "hi1234"]).valid)
+  }
+
+  func testIPv4() {
+    let schema = Schema([
+      "type": "object",
+      "properties": [
+        "ip": ["type": "string", "format": "ipv4"],
+      ],
+      "required": ["ip"],
+      ])
+
+    XCTAssertTrue(schema.validate(["ip": "192.168.1.1"]).valid)
+    XCTAssertFalse(schema.validate(["ip": "192.168.1.1.1"]).valid)
+    XCTAssertFalse(schema.validate(["ip": "192.168.1000.1"]).valid)
+    XCTAssertFalse(schema.validate(["ip": "192.168.x.1"]).valid)
+    XCTAssertFalse(schema.validate(["ip": 192.168]).valid)
+
+    let badSchema = Schema([
+      "type": "object",
+      "properties": [
+        "ip": ["type": "number", "format": "ipv4"],
+      ]
+      ])
+
+    XCTAssertFalse(badSchema.validate(["ip": "192.168.1.1"]).valid)
+    XCTAssertFalse(badSchema.validate(["ip": 192.168]).valid)
+  }
+
+  func testIPv6() {
+    let schema = Schema([
+      "type": "object",
+      "properties": [
+        "ip": ["type": "string", "format": "ipv6"],
+      ],
+      "required": ["ip"],
+      ])
+
+    // Test cases here retrieved from:
+    // https://www.helpsystems.com/intermapper/ipv6-test-address-validation
+
+    XCTAssertFalse(schema.validate(["ip":""]).valid) // empty string
+    XCTAssertTrue(schema.validate(["ip":"::1"]).valid) // loopback, compressed, non-routable
+    XCTAssertTrue(schema.validate(["ip":"::"]).valid) // unspecified, compressed, non-routable
+    XCTAssertTrue(schema.validate(["ip":"0:0:0:0:0:0:0:1"]).valid) // loopback, full
+    XCTAssertTrue(schema.validate(["ip":"0:0:0:0:0:0:0:0"]).valid) // unspecified, full
+    XCTAssertTrue(schema.validate(["ip":"2001:DB8:0:0:8:800:200C:417A"]).valid) // unicast, full
+    XCTAssertTrue(schema.validate(["ip":"FF01:0:0:0:0:0:0:101"]).valid) // multicast, full
+    XCTAssertTrue(schema.validate(["ip":"2001:DB8::8:800:200C:417A"]).valid) // unicast, compressed
+    XCTAssertTrue(schema.validate(["ip":"FF01::101"]).valid) // multicast, compressed
+    XCTAssertFalse(schema.validate(["ip":"2001:DB8:0:0:8:800:200C:417A:221"]).valid) // unicast, full
+    XCTAssertFalse(schema.validate(["ip":"FF01::101::2"]).valid) // multicast, compressed
+    XCTAssertTrue(schema.validate(["ip":"fe80::217:f2ff:fe07:ed62"]).valid)
+
+    XCTAssertTrue(schema.validate(["ip":"2001:0000:1234:0000:0000:C1C0:ABCD:0876"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"3ffe:0b00:0000:0000:0001:0000:0000:000a"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"FF02:0000:0000:0000:0000:0000:0000:0001"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0000:0000:0000:0000:0000:0000:0000:0001"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0000:0000:0000:0000:0000:0000:0000:0000"]).valid)
+//    fails, macOS 10.12.3
+//    XCTAssertFalse(schema.validate(["ip":"02001:0000:1234:0000:0000:C1C0:ABCD:0876"]).valid)	 // extra 0 not allowed!
+//    XCTAssertFalse(schema.validate(["ip":"2001:0000:1234:0000:00001:C1C0:ABCD:0876"]).valid)	 // extra 0 not allowed!
+
+    XCTAssertTrue(schema.validate(["ip":" 2001:0000:1234:0000:0000:C1C0:ABCD:0876"]).valid)		 // leading space
+    XCTAssertTrue(schema.validate(["ip":"2001:0000:1234:0000:0000:C1C0:ABCD:0876 "]).valid)		 // trailing space
+    XCTAssertTrue(schema.validate(["ip":" 2001:0000:1234:0000:0000:C1C0:ABCD:0876  "]).valid)	 // leading and trailing space
+    XCTAssertFalse(schema.validate(["ip":"2001:0000:1234:0000:0000:C1C0:ABCD:0876  0"]).valid)	 // junk after valid address
+    XCTAssertFalse(schema.validate(["ip":"2001:0000:1234: 0000:0000:C1C0:ABCD:0876"]).valid)	 // internal space
+
+    XCTAssertFalse(schema.validate(["ip":"3ffe:0b00:0000:0001:0000:0000:000a"]).valid)			 // seven segments
+    XCTAssertFalse(schema.validate(["ip":"FF02:0000:0000:0000:0000:0000:0000:0000:0001"]).valid)	 // nine segments
+    XCTAssertFalse(schema.validate(["ip":"3ffe:b00::1::a"]).valid)								 // double "::"
+    XCTAssertFalse(schema.validate(["ip":"::1111:2222:3333:4444:5555:6666::"]).valid)			 // double "::"
+    XCTAssertTrue(schema.validate(["ip":"2::10"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"ff02::1"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"fe80::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2002::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:db8::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:0db8:1234::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::ffff:0:0"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::1"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4:5:6:7:8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4:5:6::8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4:5::8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4::8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3::8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2::8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::2:3:4:5:6:7"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::2:3:4:5:6"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::2:3:4:5"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::2:3:4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::2:3"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::2:3:4:5:6:7:8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::2:3:4:5:6:7"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::2:3:4:5:6"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::2:3:4:5"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::2:3:4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::2:3"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4:5:6::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4:5::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4:5::7:8"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1:2:3::4:5::7:8"]).valid)	// Double "::"
+    XCTAssertFalse(schema.validate(["ip":"12345::6:7:8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4::7:8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3::7:8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2::7:8"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::7:8"]).valid)
+
+    // IPv4 addresses as dotted-quads
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4:5:6:1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4:5::1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4::1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3::1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2::1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3:4::5:1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2:3::5:1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1:2::5:1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::5:1.2.3.4"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1::5:11.22.33.44"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:400.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:260.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:256.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:1.256.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:1.2.256.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:1.2.3.256"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:300.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:1.300.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:1.2.300.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:1.2.3.300"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:900.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:1.900.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:1.2.900.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:1.2.3.900"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:300.300.300.300"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::5:3000.30.30.30"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::400.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::260.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::256.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::1.256.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::1.2.256.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::1.2.3.256"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::300.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::1.300.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::1.2.300.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::1.2.3.300"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::900.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::1.900.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::1.2.900.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::1.2.3.900"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::300.300.300.300"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::3000.30.30.30"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::400.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::260.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::256.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.256.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.2.256.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.2.3.256"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::300.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.300.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.2.300.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.2.3.300"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::900.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.900.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.2.900.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.2.3.900"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::300.300.300.300"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::3000.30.30.30"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"fe80::217:f2ff:254.7.237.98"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::ffff:192.168.1.26"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"2001:1:1:1:1:1:255Z255X255Y255"]).valid)	// garbage instead of "." in IPv4
+    XCTAssertFalse(schema.validate(["ip":"::ffff:192x168.1.26"]).valid)				// ditto
+    XCTAssertTrue(schema.validate(["ip":"::ffff:192.168.1.1"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0:0:0:0:0:0:13.1.68.3"]).valid) // IPv4-compatible IPv6 address, full, deprecated
+    XCTAssertTrue(schema.validate(["ip":"0:0:0:0:0:FFFF:129.144.52.38"]).valid) // IPv4-mapped IPv6 address, full
+    XCTAssertTrue(schema.validate(["ip":"::13.1.68.3"]).valid) // IPv4-compatible IPv6 address, compressed, deprecated
+    XCTAssertTrue(schema.validate(["ip":"::FFFF:129.144.52.38"]).valid) // IPv4-mapped IPv6 address, compressed
+    XCTAssertTrue(schema.validate(["ip":"fe80:0:0:0:204:61ff:254.157.241.86"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"fe80::204:61ff:254.157.241.86"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::ffff:12.34.56.78"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::ffff:2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::ffff:257.1.2.3"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1.2.3.4"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"1.2.3.4:1111:2222:3333:4444::5555"]).valid)   // Aeron
+    XCTAssertFalse(schema.validate(["ip":"1.2.3.4:1111:2222:3333::5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1.2.3.4:1111:2222::5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1.2.3.4:1111::5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1.2.3.4::5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1.2.3.4::"]).valid)
+
+    // Testing IPv4 addresses represented as dotted-quads
+    // Leading zero's in IPv4 addresses not allowed: some systems treat the leading "0" in ".086" as the start of an octal number
+    // Update: The BNF in RFC-3986 explicitly defines the dec-octet (for IPv4 addresses) not to have a leading zero
+//    XCTAssertFalse(schema.validate(["ip":"fe80:0000:0000:0000:0204:61ff:254.157.241.086"]).valid) // fails, macOS 10.12.3
+    XCTAssertTrue(schema.validate(["ip":"::ffff:192.0.2.128"]).valid)    // but this is OK, since there's a single digit
+    XCTAssertFalse(schema.validate(["ip":"XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:1.2.3.4"]).valid)
+//    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:00.00.00.00"]).valid) // fails, macOS 10.12.3
+//    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:000.000.000.000"]).valid) // fails, macOS 10.12.3
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:256.256.256.256"]).valid)
+
+    // Not testing address with subnet mask
+    // fails, macOS 10.12.3
+//    XCTAssertTrue(schema.validate(["ip":"2001:0DB8:0000:CD30:0000:0000:0000:0000/60"]).valid) // full, with prefix
+//    XCTAssertTrue(schema.validate(["ip":"2001:0DB8::CD30:0:0:0:0/60"]).valid) // compressed, with prefix
+//    XCTAssertTrue(schema.validate(["ip":"2001:0DB8:0:CD30::/60"]).valid) // compressed, with prefix #2
+//    XCTAssertTrue(schema.validate(["ip":"::/128"]).valid) // compressed, unspecified address type, non-routable
+//    XCTAssertTrue(schema.validate(["ip":"::1/128"]).valid) // compressed, loopback address type, non-routable
+//    XCTAssertTrue(schema.validate(["ip":"FF00::/8"]).valid) // compressed, multicast address type
+//    XCTAssertTrue(schema.validate(["ip":"FE80::/10"]).valid) // compressed, link-local unicast, non-routable
+//    XCTAssertTrue(schema.validate(["ip":"FEC0::/10"]).valid) // compressed, site-local unicast, deprecated
+//    XCTAssertFalse(schema.validate(["ip":"124.15.6.89/60"]).valid) // standard IPv4, prefix not allowed
+
+    XCTAssertTrue(schema.validate(["ip":"fe80:0000:0000:0000:0204:61ff:fe9d:f156"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"fe80:0:0:0:204:61ff:fe9d:f156"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"fe80::204:61ff:fe9d:f156"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::1"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"fe80::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"fe80::1"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::ffff:c000:280"]).valid)
+
+    // Aeron supplied these test cases
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444::5555:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333::5555:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::5555:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::5555:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::5555:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444::5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333::5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::"]).valid)
+
+
+    // Additional test cases
+    // from http://rt.cpan.org/Public/Bug/Display.html?id=50693
+
+    XCTAssertTrue(schema.validate(["ip":"2001:0db8:85a3:0000:0000:8a2e:0370:7334"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:db8:85a3:0:0:8a2e:370:7334"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:db8:85a3::8a2e:370:7334"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:0db8:0000:0000:0000:0000:1428:57ab"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:0db8:0000:0000:0000::1428:57ab"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:0db8:0:0:0:0:1428:57ab"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:0db8:0:0::1428:57ab"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:0db8::1428:57ab"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:db8::1428:57ab"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0000:0000:0000:0000:0000:0000:0000:0001"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::1"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::ffff:0c22:384e"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:0db8:1234:0000:0000:0000:0000:0000"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:0db8:1234:ffff:ffff:ffff:ffff:ffff"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"2001:db8:a::123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"fe80::"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"123"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"ldkfj"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"2001::FFD3::57ab"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"2001:db8:85a3::8a2e:37023:7334"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"2001:db8:85a3::8a2e:370k:7334"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1:2:3:4:5:6:7:8:9"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1::2::3"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1:::3:4:5"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1:2:3::4:5:6:7:8:9"]).valid)
+
+    // New from Aeron
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444:5555:6666::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444:5555::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::"]).valid)
+    // XCTAssertTrue(schema.validate(["ip":"::"]).valid)     #duplicate
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444:5555:6666::8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444:5555::8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444::8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333::8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444:5555::7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444::7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333::7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444::6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333::6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333::5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::4444:5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::4444:5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::4444:5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::2222:3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444:5555::123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444::123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333::123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333:4444::6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333::6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222:3333::5555:6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::5555:6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::5555:6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::5555:6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111:2222::4444:5555:6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::4444:5555:6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::4444:5555:6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"1111::3333:4444:5555:6666:123.123.123.123"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::2222:3333:4444:5555:6666:123.123.123.123"]).valid)
+
+    // Playing with combinations of "0" and "::"
+    // NB: these are all sytactically correct, but are bad form
+    //   because "0" adjacent to "::" should be combined into "::"
+    XCTAssertTrue(schema.validate(["ip":"::0:0:0:0:0:0:0"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::0:0:0:0:0:0"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::0:0:0:0:0"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::0:0:0:0"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::0:0:0"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::0:0"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::0"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0:0:0:0:0:0:0::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0:0:0:0:0:0::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0:0:0:0:0::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0:0:0:0::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0:0:0::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0:0::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"0::"]).valid)
+
+    // New invalid from Aeron
+    // Invalid data
+    XCTAssertFalse(schema.validate(["ip":"XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX"]).valid)
+
+    // Too many components
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777:8888:9999"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777:8888::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333:4444:5555:6666:7777:8888:9999"]).valid)
+
+    // Too few components
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111"]).valid)
+
+    // Missing :
+    XCTAssertFalse(schema.validate(["ip":"11112222:3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:22223333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:33334444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:44445555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:55556666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:66667777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:77778888"]).valid)
+
+    // Missing : intended for ::
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":2222:3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555:6666:7777:8888"]).valid)
+
+    // :::
+    XCTAssertFalse(schema.validate(["ip":":::2222:3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:::3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:::4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:::5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:::6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777:::"]).valid)
+
+    // Double ::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222::4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333::5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333:4444::6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333:4444:5555::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333:4444:5555:7777::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333:4444:5555:7777:8888::"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"1111::3333::5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::3333:4444::6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::3333:4444:5555::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::3333:4444:5555:6666::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::3333:4444:5555:6666:7777::"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::4444::6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::4444:5555::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::4444:5555:6666::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::4444:5555:6666:7777::"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333::5555::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333::5555:6666::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333::5555:6666:7777::"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444::6666::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444::6666:7777::"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555::7777::"]).valid)
+
+
+    // Too many components"
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777:8888:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666::1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333:4444:5555:6666:7777:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:1.2.3.4.5"]).valid)
+
+    // Too few components
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1.2.3.4"]).valid)
+
+    // Missing :
+    XCTAssertFalse(schema.validate(["ip":"11112222:3333:4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:22223333:4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:33334444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:44445555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:55556666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:66661.2.3.4"]).valid)
+
+    // Missing .
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:255255.255.255"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:255.255255.255"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:255.255.255255"]).valid)
+
+    // Missing : intended for ::
+    XCTAssertFalse(schema.validate(["ip":":1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":3333:4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":2222:3333:4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555:6666:1.2.3.4"]).valid)
+
+    // :::
+    XCTAssertFalse(schema.validate(["ip":":::2222:3333:4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:::3333:4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:::4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:::5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:::6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:::1.2.3.4"]).valid)
+
+    // Double ::
+    XCTAssertFalse(schema.validate(["ip":"::2222::4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333::5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333:4444::6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333:4444:5555::1.2.3.4"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"1111::3333::5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::3333:4444::6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::3333:4444:5555::1.2.3.4"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::4444::6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::4444:5555::1.2.3.4"]).valid)
+
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333::5555::1.2.3.4"]).valid)
+
+    // Missing parts
+    XCTAssertFalse(schema.validate(["ip":"::."]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::.."]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::..."]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1..."]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.2.."]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::1.2.3."]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::.2.."]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::.2.3."]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::..3."]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::..3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::...4"]).valid)
+
+    // Extra : in front
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555:6666:7777::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555:6666::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555:6666::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444::6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333::6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333::5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::2222:3333:4444:5555:6666:7777:8888"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444:5555::1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444::1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333::1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333:4444::6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333::6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222:3333::5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111:2222::4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":1111::3333:4444:5555:6666:1.2.3.4"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::2222:3333:4444:5555:6666:1.2.3.4"]).valid)
+
+    // Extra : at end
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:7777:::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666:::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":":::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555:6666::8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555::8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444::8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333::8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444:5555::7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444::7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333::7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333:4444::6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333::6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222:3333::5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111:2222::4444:5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::4444:5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::4444:5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"1111::3333:4444:5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::3333:4444:5555:6666:7777:8888:"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"::2222:3333:4444:5555:6666:7777:8888:"]).valid)
+    
+    // Additional cases: http://crisp.tweakblogs.net/blog/2031/ipv6-validation-%28and-caveats%29.html
+    XCTAssertTrue(schema.validate(["ip":"0:a:b:c:d:e:f::"]).valid)
+    XCTAssertTrue(schema.validate(["ip":"::0:a:b:c:d:e:f"]).valid)  // syntactically correct, but bad form (::0:... could be combined)
+    XCTAssertTrue(schema.validate(["ip":"a:b:c:d:e:f:0::"]).valid)
+    XCTAssertFalse(schema.validate(["ip":"':10.0.0.1"]).valid)
+
+  }
 }


### PR DESCRIPTION
Updates the IPv4 and IPv6 implementations and adds test cases for IPv4, IPv6, and a custom added format.

This includes the changes from #14 and #17

Note: I wrapped the validator passed to `addFormat` in a `string` type validator, as the formats functionality only makes sense for strings.


