### PR TITLE
Fix multipleOf constraint for integers

### DIFF
--- a/Sources/Validators.swift
+++ b/Sources/Validators.swift
@@ -222,14 +222,31 @@ func validatePattern(_ pattern: String) -> (_ value: Any) -> ValidationResult {
 
 // MARK: Numerical
 
+func validate(_ value: Double, multipleOf number: Double) -> ValidationResult {
+  if value.truncatingRemainder(dividingBy: number) != 0 {
+    return .invalid(["\(value) is not a multiple of \(number)"])
+  }
+  return .Valid
+}
+
+func validate(_ value: Int, multipleOf number: Int) -> ValidationResult {
+  if value % number != 0 {
+    return .invalid(["\(value) is not a multiple of \(number)"])
+  }
+  return .Valid
+}
+
 func validateMultipleOf(_ number: Double) -> (_ value: Any) -> ValidationResult {
   return { value in
     if number > 0.0 {
       if let value = value as? Double {
-        let result = value / number
-        if result != floor(result) {
-          return .invalid(["\(value) is not a multiple of \(number)"])
+        return validate(value, multipleOf: number)
+      }
+      if let value = value as? Int {
+        if number.truncatingRemainder(dividingBy: 1) == 0 {
+          return validate(value, multipleOf: Int(number))
         }
+        return validate(Double(value), multipleOf: number)
       }
     }
 


### PR DESCRIPTION
Proposal to fix the `multipleOf` constraint for integers. In fact, it wasn't working so far for the type `integer`. If the value passed was a Swift `Int`, we got `value as? Double` being evaluated to `nil`.

I made some changes, to try to coherce both `number` and `value` into an `Int` to use the standard modulo operator. And fallback on floating point comparison.

Also, I've replaced the previous `floor`ing method by `truncatingRemainder(dividingBy:)` for floating point division.

Let me know what you think @kylef I'm happy to make any changes if coding style or implementation isn't matching the current project standards. Thanks in advance!