### PR TITLE
Swift warning fix

### DIFF
--- a/Sources/Validators.swift
+++ b/Sources/Validators.swift
@@ -278,8 +278,8 @@ func validateUniqueItems(_ value: Any) -> ValidationResult {
     }
 
     let numbers = value.filter { value in value is NSNumber } as! [NSNumber]
-    let numerBooleans = numbers.filter(isBoolean)
-    let booleans = numerBooleans as [Bool]
+    let numberBooleans = numbers.filter(isBoolean)
+    let booleans = numberBooleans as! [Bool]
     let nonBooleans = numbers.filter { number in !isBoolean(number) }
     let hasTrueAndOne = booleans.filter { v in v }.count > 0 && nonBooleans.filter { v in v == 1 }.count > 0
     let hasFalseAndZero = booleans.filter { v in !v }.count > 0 && nonBooleans.filter { v in v == 0 }.count > 0

--- a/Sources/Validators.swift
+++ b/Sources/Validators.swift
@@ -279,7 +279,7 @@ func validateUniqueItems(_ value: Any) -> ValidationResult {
 
     let numbers = value.filter { value in value is NSNumber } as! [NSNumber]
     let numberBooleans = numbers.filter(isBoolean)
-    let booleans = numberBooleans as! [Bool]
+    let booleans = numberBooleans as? [Bool] ?? []
     let nonBooleans = numbers.filter { number in !isBoolean(number) }
     let hasTrueAndOne = booleans.filter { v in v }.count > 0 && nonBooleans.filter { v in v == 1 }.count > 0
     let hasFalseAndZero = booleans.filter { v in !v }.count > 0 && nonBooleans.filter { v in v == 0 }.count > 0


### PR DESCRIPTION
Fix compiler warning:
`/Pods/JSONSchema/Sources/Validators.swift:282:34: Bridging '[NSNumber]' to '[Bool]' may fail at runtime and will become a checked cast in Swift 4; did you mean to use 'as!' to force downcast?`