### PR TITLE
Refactor code that uses deprecated framework methods

### DIFF
--- a/Sources/JSONSchema.swift
+++ b/Sources/JSONSchema.swift
@@ -22,7 +22,7 @@ extension String {
   func stringByRemovingPrefix(_ prefix:String) -> String? {
     if hasPrefix(prefix) {
       let index = self.index(startIndex, offsetBy: prefix.count)
-      return substring(from: index)
+      return String(self[index...])
     }
 
     return nil

--- a/Tests/JSONSchemaTests/JSONSchemaCases.swift
+++ b/Tests/JSONSchemaTests/JSONSchemaCases.swift
@@ -83,7 +83,7 @@ struct Test {
 }
 
 func makeTest(_ object:[String:Any]) -> Test {
-  return Test(description: object["description"] as! String, data: object["data"] as Any!, value: object["valid"] as! Bool)
+  return Test(description: object["description"] as! String, data: object["data"] as Any, value: object["valid"] as! Bool)
 }
 
 struct Case {


### PR DESCRIPTION
Fix some code snippets that use calls of (soon-to-be) deprecated methods.