### PR TITLE
Directly reference metaschema

### DIFF
--- a/Sources/JSONSchema.swift
+++ b/Sources/JSONSchema.swift
@@ -72,15 +72,15 @@ func validator(for schema: [String: Any]) -> Validator {
     return Draft4Validator(schema: schema)
   }
 
-  if let id = Draft7Validator.metaSchema["$id"] as? String, schemaURI == id {
+  if let id = DRAFT_07_META_SCHEMA["$id"] as? String, schemaURI == id {
     return Draft7Validator(schema: schema)
   }
 
-  if let id = Draft6Validator.metaSchema["$id"] as? String, schemaURI == id {
+  if let id = DRAFT_06_META_SCHEMA["$id"] as? String, schemaURI == id {
     return Draft6Validator(schema: schema)
   }
 
-  if let id = Draft4Validator.metaSchema["$id"] as? String, schemaURI == id {
+  if let id = DRAFT_04_META_SCHEMA["$id"] as? String, schemaURI == id {
     return Draft4Validator(schema: schema)
   }
 

--- a/Tests/JSONSchemaTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaTests/JSONSchemaTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import JSONSchema
+@testable import JSONSchema
 
 
 class JSONSchemaTests: XCTestCase {
@@ -81,6 +81,11 @@ class ValidateTests: XCTestCase {
 
     XCTAssertTrue(validate(["name": "Eggs", "price": 34.99], schema: schema).valid)
     XCTAssertFalse(validate(["price": 34.99], schema: schema).valid)
+  }
+
+  func testDraft6ValidatorIsAvailable() {
+    let result = validator(for: ["$schema": "http://json-schema.org/draft-06/schema#"])
+    XCTAssertTrue(result is Draft6Validator, "Unexpected type of validator \(result)")
   }
 
   func testValidateDraft7() {


### PR DESCRIPTION
Because `Draft6Validator` is `typealias` as  `Draft7Validator`, the vendor method was picking up from the wrong meta schema.