### PR TITLE
Fix typo of Number

### DIFF
--- a/Sources/JSONSchema.swift
+++ b/Sources/JSONSchema.swift
@@ -6,7 +6,7 @@ public enum Type: Swift.String {
   case array = "array"
   case string = "string"
   case integer = "integer"
-  case jumber = "number"
+  case number = "number"
   case boolean = "boolean"
   case null = "null"
 }


### PR DESCRIPTION
Unless I am missing something, I think this is a typo. All tests passing with the change.

![image](https://user-images.githubusercontent.com/235322/88721696-8ec65800-d0db-11ea-8dd7-a9147f402123.png)
