### PR TITLE
Update JSONSchema.podspec

### DIFF
--- a/JSONSchema.podspec
+++ b/JSONSchema.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = '8.0'
   spec.osx.deployment_target = '10.9'
   spec.requires_arc = true
-  spec.source_files = 'Sources/**.swift'
+  spec.source_files = ['Sources/**/*.swift', 'Sources/*.swift']
   spec.swift_versions = ['5.0', '5.1']
 end
 


### PR DESCRIPTION
fix source files spec

At this moment installed framework via CocoaPods doesn't contain files from Applicators, Core, Validation folders.