### PR TITLE
Add key information to instance location when validating required fields of a schema

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "JSONSchema",
   platforms: [
-    .macOS(.v10_13),
+    .macOS(.v10_13), .iOS(.v11), .tvOS(.v11)
   ],
   products: [
     .library(name: "JSONSchema", targets: ["JSONSchema"]),

--- a/Sources/RefResolver.swift
+++ b/Sources/RefResolver.swift
@@ -1,9 +1,15 @@
 import Foundation
 
 func urlSplitFragment(url: String) -> (String, String) {
+  #if swift(>=5.0)
+  guard let hashIndex = url.firstIndex(of: "#") else {
+    return (url, "")
+  }
+  #else
   guard let hashIndex = url.index(of: "#") else {
     return (url, "")
   }
+  #endif
 
   return (
     String(url.prefix(upTo: hashIndex)),

--- a/Sources/Validation/required.swift
+++ b/Sources/Validation/required.swift
@@ -10,6 +10,8 @@ func required(context: Context, required: Any, instance: Any, schema: [String: A
 
   return AnySequence(required.compactMap { key -> ValidationError? in
     guard !instance.keys.contains(key) else { return nil }
+    context.instanceLocation.push(key)
+    defer { context.instanceLocation.pop() }
     return ValidationError(
       "Required property '\(key)' is missing",
       instanceLocation: context.instanceLocation,

--- a/Tests/JSONSchemaTests/Validation/TestRequired.swift
+++ b/Tests/JSONSchemaTests/Validation/TestRequired.swift
@@ -21,7 +21,7 @@ public let testRequired: ((ContextType) -> Void) = {
       let error = errors[0]
 
       try expect(error.description) == "Required property 'test' is missing"
-      try expect(error.instanceLocation.path) == "/0"
+      try expect(error.instanceLocation.path) == "/0/test"
       try expect(error.keywordLocation.path) == "#/items/required"
     }
   }


### PR DESCRIPTION
This adds the currently validating key to the `instanceLocation` `JSONPointer` when validating required fields in a schema. We need this since we want to find out which fields specifically are missing from the data we're looking to upload, so that we can show errors in the right place in our UI that corresponds with each required field.

This also fixes a deprecation warning when using swift 5.0 and above, and fixes a compiler issue where the library was using iOS 11 api without declaring iOS 11 as a minimum deployment target.