### PR TITLE
Update RefResolver.swift

### DIFF
--- a/Sources/RefResolver.swift
+++ b/Sources/RefResolver.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func urlSplitFragment(url: String) -> (String, String) {
-  guard let hashIndex = url.index(of: "#") else {
+  guard let hashIndex = url.firstIndex(of: "#") else {
     return (url, "")
   }
 


### PR DESCRIPTION
Fix compiler issue, `index(of:)` is deprecated: renamed to `firstIndex(of:)`.