### PR TITLE
xcode 14.3 compatibility

### DIFF
--- a/JSONSchema.podspec
+++ b/JSONSchema.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
   spec.author = { 'Kyle Fuller' => 'kyle@fuller.li' }
   spec.social_media_url = 'http://twitter.com/kylefuller'
   spec.source = { :git => 'https://github.com/kylef/JSONSchema.swift.git', :tag => "#{spec.version}" }
-  spec.ios.deployment_target = '8.0'
+  spec.ios.deployment_target = '11.0'
   spec.osx.deployment_target = '10.13'
   spec.requires_arc = true
   spec.source_files = ['Sources/**/*.swift', 'Sources/*.swift']

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 let package = Package(
   name: "JSONSchema",
   platforms: [
+    .iOS(.v11),
     .macOS(.v10_13),
   ],
   products: [


### PR DESCRIPTION
fixes below issues when using Xcode 14.3 to run pod lib lint on the pod spec. Also updated Package.swift file 

-> JSONSchema (0.6.0)
    - NOTE  | url: The URL (http://twitter.com/kylefuller) is not reachable.
    - ERROR | [iOS] xcodebuild: Returned an unsuccessful exit code.
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Building targets in dependency order
    - WARN  | xcodebuild:  
    - ERROR | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:76:33: error: 'range(withName:)' is only available in iOS 11.0 or newer
    - NOTE  | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:76:33: note: add 'if #available' version check
    - NOTE  | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:71:3: note: add @available attribute to enclosing initializer
    - NOTE  | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:58:8: note: add @available attribute to enclosing struct
    - ERROR | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:79:35: error: 'range(withName:)' is only available in iOS 11.0 or newer
    - NOTE  | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:79:35: note: add 'if #available' version check
    - ERROR | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:82:35: error: 'range(withName:)' is only available in iOS 11.0 or newer
    - NOTE  | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:82:35: note: add 'if #available' version check
    - ERROR | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:85:20: error: 'range(withName:)' is only available in iOS 11.0 or newer
    - NOTE  | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:85:20: note: add 'if #available' version check
    - ERROR | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:86:41: error: 'range(withName:)' is only available in iOS 11.0 or newer
    - NOTE  | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:86:41: note: add 'if #available' version check
    - ERROR | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:88:41: error: 'range(withName:)' is only available in iOS 11.0 or newer
    - NOTE  | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:88:41: note: add 'if #available' version check
    - ERROR | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:91:43: error: 'range(withName:)' is only available in iOS 11.0 or newer
    - NOTE  | xcodebuild:  /Users/nkuninti/Documents/JSONSchema/JSONSchema.swift/Sources/Format/time.swift:91:43: note: add 'if #available' version check
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'Pods-App' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'JSONSchema' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  /var/folders/qm/2j1_fcg57bq62slhfc1sy2880000gr/T/CocoaPods-Lint-20230620-46296-1lpzd6a-JSONSchema/App.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'App' from project 'App')
    - NOTE  | xcodebuild:  note: Using codesigning identity override: 
    - NOTE  | [OSX] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'JSONSchema' from project 'Pods')
    - NOTE  | [OSX] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'App' from project 'App')

[!] JSONSchema did not pass validation, due to 8 errors.
You can use the `--no-clean` option to inspect any issue.
